### PR TITLE
Change access to getRenderer method in Email class

### DIFF
--- a/source/Core/Email.php
+++ b/source/Core/Email.php
@@ -347,7 +347,7 @@ class Email extends PHPMailer
      *
      * @return TemplateRendererInterface
      */
-    private function getRenderer()
+    protected function getRenderer()
     {
         $bridge = $this->getContainer()->get(TemplateRendererBridgeInterface::class);
         $bridge->setEngine($this->_getSmarty());


### PR DESCRIPTION
The Email class is often extended with own send methods for additional email functionality. To adapt the core principals of the logic from this class it is crucial to have access to the getRenderer method in extended classes, otherwise it needs to be reemplemented every single time.